### PR TITLE
Docedex set up to allow for Patient manipulation

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -11,6 +11,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.doctor.Doctor;
+import seedu.address.model.person.patient.Patient;
 
 /**
  * API of the Logic component
@@ -37,6 +38,9 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of doctors */
     ObservableList<Doctor> getFilteredDoctorList();
+
+    /** Returns an unmodifiable view of the filtered list of patients */
+    ObservableList<Patient> getFilteredPatientList();
 
     /** Returns an Optional containing a doctor if the filtered list of doctors is not empty */
     Optional<Doctor> getDoctorIfPresent();

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -17,6 +17,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.doctor.Doctor;
+import seedu.address.model.person.patient.Patient;
 import seedu.address.storage.Storage;
 
 /**
@@ -69,6 +70,11 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Doctor> getFilteredDoctorList() {
         return model.getFilteredDoctorList();
+    }
+
+    @Override
+    public ObservableList<Patient> getFilteredPatientList() {
+        return model.getFilteredPatientList();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -9,6 +9,8 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 import seedu.address.model.person.doctor.Doctor;
 import seedu.address.model.person.doctor.UniqueDoctorList;
+import seedu.address.model.person.patient.Patient;
+import seedu.address.model.person.patient.UniquePatientList;
 
 /**
  * Wraps all data at the address-book level
@@ -18,6 +20,7 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
     private final UniqueDoctorList doctors;
+    private final UniquePatientList patients;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -29,6 +32,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     {
         persons = new UniquePersonList();
         doctors = new UniqueDoctorList();
+        patients = new UniquePatientList();
     }
 
     public AddressBook() {}
@@ -60,6 +64,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Replaces the contents of the patients list with {@code patients}.
+     * {@code patients} must not contain duplicate patients.
+     */
+    public void setPatients(List<Patient> patients) {
+        this.patients.setPatients(patients);
+    }
+
+    /**
      * Resets the existing data of this {@code AddressBook} with {@code newData}.
      */
     public void resetData(ReadOnlyAddressBook newData) {
@@ -67,6 +79,7 @@ public class AddressBook implements ReadOnlyAddressBook {
 
         setPersons(newData.getPersonList());
         setDoctors(newData.getDoctorList());
+        setPatients(newData.getPatientList());
     }
 
     //// person-level operations
@@ -88,6 +101,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if a patient with the same identity as {@code patient} exists in the address book.
+     */
+    public boolean hasPatient(Patient patient) {
+        requireNonNull(patient);
+        return patients.contains(patient);
+    }
+
+    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */
@@ -102,6 +123,14 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void addDoctor(Doctor doctor) {
         doctors.add(doctor);
+    }
+
+    /**
+     * Adds a patient to the address book.
+     * The patient must not already exist in the address book.
+     * @param patient
+     */
+    public void addPatient(Patient patient) {patients.add(patient);
     }
 
     /**
@@ -127,19 +156,38 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Removes {@code key} from this {@code AddressBook}.
-     * {@code key} must exist in the address book.
+     * Replaces the given patient {@code target} in the list with {@code editedPatient}.
+     * {@code target} must exist in the address book.
+     * The patient identity of {@code editedPatient} must not be the same as another existing patient in the address book.
+     */
+    public void setPatient(Patient target, Patient editedPerson) {
+        requireNonNull(editedPerson);
+
+        patients.setPatient(target, editedPerson);
+    }
+
+    /**
+     * Removes {@code key} from {@code persons}.
+     * {@code key} must exist in {@code persons}.
      */
     public void removePerson(Person key) {
         persons.remove(key);
     }
 
     /**
-     * Removes {@code key} from this {@code AddressBook}.
-     * {@code key} must exist in the address book.
+     * Removes {@code key} from {@code doctors}.
+     * {@code key} must exist in {@code doctors}.
      */
     public void removeDoctor(Doctor key) {
         doctors.remove(key);
+    }
+
+    /**
+     * Removes {@code key} from {@code patients}.
+     * {@code key} must exist in {@code patients}.
+     */
+    public void removePatient(Patient key) {
+        patients.remove(key);
     }
 
     //// util methods
@@ -161,14 +209,22 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
+    public ObservableList<Patient> getPatientList() {
+        return patients.asUnmodifiableObservableList();
+    }
+
+
+    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AddressBook // instanceof handles nulls
-                && persons.equals(((AddressBook) other).persons));
+                && persons.equals(((AddressBook) other).persons)
+                && doctors.equals(((AddressBook) other).doctors)
+                && patients.equals(((AddressBook) other).patients));
     }
 
     @Override
     public int hashCode() {
-        return persons.hashCode();
+        return doctors.hashCode();
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -130,7 +130,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      * The patient must not already exist in the address book.
      * @param patient
      */
-    public void addPatient(Patient patient) {patients.add(patient);
+    public void addPatient(Patient patient) {
+        patients.add(patient);
     }
 
     /**
@@ -158,7 +159,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Replaces the given patient {@code target} in the list with {@code editedPatient}.
      * {@code target} must exist in the address book.
-     * The patient identity of {@code editedPatient} must not be the same as another existing patient in the address book.
+     * The patient identity of {@code editedPatient} must not be the same as
+     * another existing patient in the address book.
      */
     public void setPatient(Patient target, Patient editedPerson) {
         requireNonNull(editedPerson);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -7,6 +7,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.doctor.Doctor;
+import seedu.address.model.person.patient.Patient;
 
 /**
  * The API of the Model component.
@@ -15,6 +16,7 @@ public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
     Predicate<Doctor> PREDICATE_SHOW_ALL_DOCTORS = unused -> true;
+    Predicate<Patient> PREDICATE_SHOW_ALL_PATIENTS = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -65,10 +67,27 @@ public interface Model {
     boolean hasDoctor(Doctor doctor);
 
     /**
+     * Returns true if a patient with the same identity as {@code patient} exists in the address book.
+     */
+    boolean hasPatient(Patient patient);
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */
     void deletePerson(Person target);
+
+    /**
+     * Deletes the given doctor.
+     * The person must exist in the address book.
+     */
+    void deleteDoctor(Doctor target);
+
+    /**
+     * Deletes the given patient.
+     * The person must exist in the address book.
+     */
+    void deletePatient(Patient target);
 
     /**
      * Adds the given person.
@@ -82,6 +101,11 @@ public interface Model {
      */
     void addDoctor(Doctor doctor);
 
+    /**
+     * Adds the given patient.
+     * {@code patient} must not already exist in the address book.
+     */
+    void addPatient(Patient patient);
 
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
@@ -97,11 +121,21 @@ public interface Model {
      */
     void setDoctor(Doctor target, Doctor editedDoctor);
 
+    /**
+     * Replaces the given patient {@code target} with {@code editedPatient}.
+     * {@code target} must exist in the address book.
+     * The patient identity of {@code editedPatient} must not be the same as another existing patient in the address book.
+     */
+    void setPatient(Patient target, Patient editedPatient);
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
     /** Returns an unmodifiable view of the filtered doctor list */
     ObservableList<Doctor> getFilteredDoctorList();
+
+    /** Returns an unmodifiable view of the filtered patient list */
+    ObservableList<Patient> getFilteredPatientList();
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
@@ -115,10 +149,9 @@ public interface Model {
      */
     void updateFilteredDoctorList(Predicate<Doctor> predicate);
 
-
     /**
-     * Deletes the given doctor.
-     * The person must exist in the address book.
+     * Updates the filter of the filtered patient list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
      */
-    void deleteDoctor(Doctor target);
+    void updateFilteredPatientList(Predicate<Patient> predicate);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -124,7 +124,8 @@ public interface Model {
     /**
      * Replaces the given patient {@code target} with {@code editedPatient}.
      * {@code target} must exist in the address book.
-     * The patient identity of {@code editedPatient} must not be the same as another existing patient in the address book.
+     * The patient identity of {@code editedPatient} must not be the same
+     * as another existing patient in the address book.
      */
     void setPatient(Patient target, Patient editedPatient);
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -122,7 +122,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean deletePatient(Patient patient) {
+    public void deletePatient(Patient patient) {
         addressBook.removePatient(patient);
     }
 
@@ -139,7 +139,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean addPatient(Patient patient) {
+    public void addPatient(Patient patient) {
         addressBook.addPatient(patient);
         updateFilteredPatientList(PREDICATE_SHOW_ALL_PATIENTS);
     }
@@ -159,7 +159,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean setPatient(Patient target, Patient editedPatient) {
+    public void setPatient(Patient target, Patient editedPatient) {
         requireAllNonNull(target, editedPatient);
 
         addressBook.setPatient(target, editedPatient);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.doctor.Doctor;
+import seedu.address.model.person.patient.Patient;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -24,6 +25,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
     private final FilteredList<Doctor> filteredDoctors;
+    private final FilteredList<Patient> filteredPatients;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -37,6 +39,7 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         filteredDoctors = new FilteredList<>(this.addressBook.getDoctorList());
+        filteredPatients = new FilteredList<>(this.addressBook.getPatientList());
     }
 
     public ModelManager() {
@@ -103,6 +106,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasPatient(Patient patient) {
+        requireNonNull(patient);
+        return addressBook.hasPatient(patient);
+    }
+
+    @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
     }
@@ -110,6 +119,11 @@ public class ModelManager implements Model {
     @Override
     public void deleteDoctor(Doctor target) {
         addressBook.removeDoctor(target);
+    }
+
+    @Override
+    public boolean deletePatient(Patient patient) {
+        addressBook.removePatient(patient);
     }
 
     @Override
@@ -125,6 +139,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean addPatient(Patient patient) {
+        addressBook.addPatient(patient);
+        updateFilteredPatientList(PREDICATE_SHOW_ALL_PATIENTS);
+    }
+
+    @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
 
@@ -136,6 +156,13 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedDoctor);
 
         addressBook.setDoctor(target, editedDoctor);
+    }
+
+    @Override
+    public boolean setPatient(Patient target, Patient editedPatient) {
+        requireAllNonNull(target, editedPatient);
+
+        addressBook.setPatient(target, editedPatient);
     }
 
     //=========== Filtered Person List Accessors =============================================================
@@ -155,6 +182,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public ObservableList<Patient> getFilteredPatientList() {
+        return filteredPatients;
+    }
+
+    @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
@@ -164,6 +196,12 @@ public class ModelManager implements Model {
     public void updateFilteredDoctorList(Predicate<Doctor> predicate) {
         requireNonNull(predicate);
         filteredDoctors.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredPatientList(Predicate<Patient> predicate) {
+        requireNonNull(predicate);
+        filteredPatients.setPredicate(predicate);
     }
 
     @Override
@@ -183,7 +221,8 @@ public class ModelManager implements Model {
         return addressBook.equals(other.addressBook)
                 && userPrefs.equals(other.userPrefs)
                 && filteredPersons.equals(other.filteredPersons)
-                && filteredDoctors.equals(other.filteredDoctors);
+                && filteredDoctors.equals(other.filteredDoctors)
+                && filteredPatients.equals(other.filteredPatients);
     }
 
 }

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.doctor.Doctor;
+import seedu.address.model.person.patient.Patient;
 
 /**
  * Unmodifiable view of an address book
@@ -19,5 +20,10 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate persons.
      */
     ObservableList<Doctor> getDoctorList();
+    /**
+     * Returns an unmodifiable view of the patients list.
+     * This list will not contain any duplicate persons.
+     */
+    ObservableList<Patient> getPatientList();
 
 }

--- a/src/main/java/seedu/address/model/person/doctor/Doctor.java
+++ b/src/main/java/seedu/address/model/person/doctor/Doctor.java
@@ -2,6 +2,7 @@ package seedu.address.model.person.doctor;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -29,6 +30,18 @@ public class Doctor extends Person {
         this.specialty = specialty;
         this.yoe = yoe;
         this.patients = patients;
+    }
+
+    /**
+     * Initializes {@code Doctor} object without {@code patients}.
+     * Every field must be present and not null.
+     */
+    public Doctor(Name name, Phone phone, Email email, Specialty specialty, Yoe yoe, Set<Tag> tags) {
+        super(name, phone, email, tags);
+        requireAllNonNull(name, phone, email, specialty, yoe, tags);
+        this.specialty = specialty;
+        this.yoe = yoe;
+        this.patients = new HashSet<>();
     }
 
     public Specialty getSpecialty() {

--- a/src/main/java/seedu/address/model/person/doctor/Doctor.java
+++ b/src/main/java/seedu/address/model/person/doctor/Doctor.java
@@ -9,6 +9,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.patient.Patient;
 import seedu.address.model.tag.Tag;
 /**
  * Represents a Doctor in the address book.
@@ -18,21 +19,28 @@ public class Doctor extends Person {
     // Identity fields
     private final Specialty specialty;
     private final Yoe yoe;
+    private final Set<Patient> patients;
     /**
      * Every field must be present and not null.
      */
-    public Doctor(Name name, Phone phone, Email email, Specialty specialty, Yoe yoe, Set<Tag> tags) {
+    public Doctor(Name name, Phone phone, Email email, Specialty specialty, Yoe yoe, Set<Tag> tags, Set<Patient> patients) {
         super(name, phone, email, tags);
-        requireAllNonNull(name, phone, email, specialty, yoe, tags);
+        requireAllNonNull(name, phone, email, specialty, yoe, tags, patients);
         this.specialty = specialty;
         this.yoe = yoe;
+        this.patients = patients;
     }
 
     public Specialty getSpecialty() {
         return specialty;
     }
+
     public Yoe getYoe() {
         return yoe;
+    }
+
+    public Set<Patient> getPatients() {
+        return patients;
     }
 
     /**
@@ -94,6 +102,14 @@ public class Doctor extends Person {
         if (!tags.isEmpty()) {
             builder.append("; Tags: ");
             tags.forEach(builder::append);
+        }
+
+        Set<Patient> patients = getPatients();
+        if (!patients.isEmpty()) {
+            builder.append("; Patients: ");
+            patients.forEach((Patient patient) -> {
+                builder.append(patient.getName());
+            });
         }
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/person/doctor/Doctor.java
+++ b/src/main/java/seedu/address/model/person/doctor/Doctor.java
@@ -24,7 +24,8 @@ public class Doctor extends Person {
     /**
      * Every field must be present and not null.
      */
-    public Doctor(Name name, Phone phone, Email email, Specialty specialty, Yoe yoe, Set<Tag> tags, Set<Patient> patients) {
+    public Doctor(Name name, Phone phone, Email email,
+                  Specialty specialty, Yoe yoe, Set<Tag> tags, Set<Patient> patients) {
         super(name, phone, email, tags);
         requireAllNonNull(name, phone, email, specialty, yoe, tags, patients);
         this.specialty = specialty;

--- a/src/main/java/seedu/address/model/person/doctor/DoctorStub.java
+++ b/src/main/java/seedu/address/model/person/doctor/DoctorStub.java
@@ -6,6 +6,7 @@ import java.util.List;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.patient.PatientStub;
 import seedu.address.model.tag.Tag;
 /**
  * Represents a Doctor with pre-filled attributes.
@@ -17,7 +18,8 @@ public class DoctorStub extends Doctor {
     public DoctorStub() {
         super(new Name("John Doe"), new Phone("88887777"),
                 new Email("prawn@gmail.com"), new Specialty("GP"), new Yoe("1"),
-                new HashSet<>(List.of(new Tag("Friend"), new Tag("College"))));
+                new HashSet<>(List.of(new Tag("Friend"), new Tag("College"))),
+                new HashSet<>(List.of(new PatientStub())));
     }
 
 }

--- a/src/main/java/seedu/address/model/person/patient/PatientStub.java
+++ b/src/main/java/seedu/address/model/person/patient/PatientStub.java
@@ -1,0 +1,26 @@
+package seedu.address.model.person.patient;
+
+import java.util.HashSet;
+import java.util.List;
+
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Represents a Patient with pre-filled attributes.
+ */
+public class PatientStub extends Patient {
+    /**
+     * Constructor for {@code PatientStub}
+     */
+    public PatientStub() {
+        super(new Name("John Doe"), new Phone("88887777"),
+                new Email("prawn@gmail.com"), new Height("1.7"), new Weight("63.4"), new Diagnosis("None"),
+                new Status("Processed"), new Remark("Compliant"),
+                new HashSet<>(List.of(new Tag("Friend"), new Tag("College"))));
+    }
+
+}
+

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -6,22 +6,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
+import seedu.address.model.ModelStub;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.doctor.Doctor;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -73,111 +67,6 @@ public class AddCommandTest {
 
         // different person -> returns false
         assertFalse(addAliceCommand.equals(addBobCommand));
-    }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addDoctor(Doctor doctor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasDoctor(Doctor doctor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setDoctor(Doctor target, Doctor editedDoctor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Doctor> getFilteredDoctorList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredDoctorList(Predicate<Doctor> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteDoctor(Doctor target) {
-
-        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddDoctorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddDoctorCommandTest.java
@@ -6,21 +6,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
+import seedu.address.model.ModelStub;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.doctor.Doctor;
 import seedu.address.testutil.DoctorBuilder;
 
@@ -49,7 +43,7 @@ public class AddDoctorCommandTest {
     public void execute_duplicateDoctor_throwsCommandException() {
         Doctor validDoctor = new DoctorBuilder().build();
         AddDoctorCommand addDoctorCommand = new AddDoctorCommand(validDoctor);
-        AddDoctorCommandTest.ModelStub modelStub = new AddDoctorCommandTest.ModelStubWithDoctor(validDoctor);
+        ModelStub modelStub = new AddDoctorCommandTest.ModelStubWithDoctor(validDoctor);
 
         assertThrows(CommandException.class, AddDoctorCommand.MESSAGE_DUPLICATE_DOCTOR, () ->
                 addDoctorCommand.execute(modelStub));
@@ -77,110 +71,6 @@ public class AddDoctorCommandTest {
 
         // different person -> returns false
         assertFalse(addAliceCommand.equals(addBobCommand));
-    }
-
-
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addDoctor(Doctor doctor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-
-        @Override
-        public boolean hasDoctor(Doctor doctor) {
-            return false;
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            return false;
-        }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setDoctor(Doctor target, Doctor editedDoctor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Doctor> getFilteredDoctorList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredDoctorList(Predicate<Doctor> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteDoctor(Doctor target) {
-
-        }
     }
 
     /**

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -20,6 +20,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.doctor.Doctor;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.patient.Patient;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddressBookTest {
@@ -88,6 +89,7 @@ public class AddressBookTest {
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
         private final ObservableList<Doctor> doctors = FXCollections.observableArrayList();
+        private final ObservableList<Patient> patients = FXCollections.observableArrayList();
 
         AddressBookStub(Collection<Person> persons) {
             this.persons.setAll(persons);
@@ -101,6 +103,11 @@ public class AddressBookTest {
         @Override
         public ObservableList<Doctor> getDoctorList() {
             return doctors;
+        }
+
+        @Override
+        public ObservableList<Patient> getPatientList() {
+            return patients;
         }
     }
 

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -1,0 +1,145 @@
+package seedu.address.model;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.doctor.Doctor;
+import seedu.address.model.person.patient.Patient;
+
+/**
+ * A default model stub that have all the methods failing.
+ */
+public class ModelStub implements Model {
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Path getAddressBookFilePath() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBookFilePath(Path addressBookFilePath) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addPerson(Person person) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addDoctor(Doctor doctor) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addPatient(Patient patient) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasPerson(Person person) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasDoctor(Doctor doctor) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasPatient(Patient patient) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBook(ReadOnlyAddressBook newData) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deletePerson(Person target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteDoctor(Doctor target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deletePatient(Patient target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setPerson(Person target, Person editedPerson) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setDoctor(Doctor target, Doctor editedDoctor) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setPatient(Patient target, Patient editedPatient) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Person> getFilteredPersonList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Doctor> getFilteredDoctorList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Patient> getFilteredPatientList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredPersonList(Predicate<Person> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredDoctorList(Predicate<Doctor> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredPatientList(Predicate<Patient> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+}

--- a/src/test/java/seedu/address/testutil/DoctorBuilder.java
+++ b/src/test/java/seedu/address/testutil/DoctorBuilder.java
@@ -10,6 +10,7 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.person.doctor.Doctor;
 import seedu.address.model.person.doctor.Specialty;
 import seedu.address.model.person.doctor.Yoe;
+import seedu.address.model.person.patient.Patient;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -30,9 +31,10 @@ public class DoctorBuilder {
     private Specialty specialty;
     private Yoe yoe;
     private Set<Tag> tags;
+    private Set<Patient> patients;
 
     /**
-     * Creates a {@code PersonBuilder} with the default details.
+     * Creates a {@code DoctorBuilder} with the default details.
      */
     public DoctorBuilder() {
         name = new Name(DEFAULT_NAME);
@@ -41,10 +43,11 @@ public class DoctorBuilder {
         specialty = new Specialty(DEFAULT_SPECIALTY);
         yoe = new Yoe(DEFAULT_YOE);
         tags = new HashSet<>();
+        patients = new HashSet<>();
     }
 
     /**
-     * Initializes the PersonBuilder with the data of {@code personToCopy}.
+     * Initializes the DoctorBuilder with the data of {@code doctorToCopy}.
      */
     public DoctorBuilder(Doctor doctorToCopy) {
         name = doctorToCopy.getName();
@@ -53,6 +56,7 @@ public class DoctorBuilder {
         specialty = doctorToCopy.getSpecialty();
         yoe = doctorToCopy.getYoe();
         tags = new HashSet<>(doctorToCopy.getTags());
+        patients = new HashSet<>(doctorToCopy.getPatients());
     }
 
     /**
@@ -64,7 +68,7 @@ public class DoctorBuilder {
     }
 
     /**
-     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Doctor} that we are building.
      */
     public DoctorBuilder withTags(String ... tags) {
         this.tags = SampleDataUtil.getTagSet(tags);


### PR DESCRIPTION
**What's been done**
- `AddressBook`, `Logic`, `Model` and `Doctor` have been updated to allow for `Patient` manipulation.

**Things to note**
- Each `Patient` should be stored in two areas
   - in the respective `Doctor`: `Set<Patients> patients` attribute
   - in the `AddressBook`: `UniquePatientList patients` attribute
      - I believe this attribute can be modified through `ModelManager` too. 