### PR TITLE
Enable proper loading of multiple patients and display of selection queries

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -2,6 +2,7 @@ package seedu.address.logic;
 
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
@@ -41,6 +42,20 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of patients */
     ObservableList<Patient> getFilteredPatientList();
+
+    /**
+     * Updates the filter of the filtered doctor list in {@code Model}
+     * to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredDoctorList(Predicate<Doctor> predicate);
+
+    /**
+     * Updates the filter of the filtered patient list in {@code Model}
+     * to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredPatientList(Predicate<Patient> predicate);
 
     /** Returns an Optional containing a doctor if the filtered list of doctors is not empty */
     Optional<Doctor> getDoctorIfPresent();

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -1,8 +1,11 @@
 package seedu.address.logic;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -75,6 +78,18 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Patient> getFilteredPatientList() {
         return model.getFilteredPatientList();
+    }
+
+    @Override
+    public void updateFilteredDoctorList(Predicate<Doctor> predicate) {
+        requireNonNull(predicate);
+        model.updateFilteredDoctorList(predicate);
+    }
+
+    @Override
+    public void updateFilteredPatientList(Predicate<Patient> predicate) {
+        requireNonNull(predicate);
+        model.updateFilteredPatientList(predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AssignPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignPatientCommand.java
@@ -57,8 +57,10 @@ public class AssignPatientCommand extends Command {
         Doctor doctorToAssign = lastShownDoctorList.get(doctorIndex.getZeroBased());
 
         Doctor doctorWithAssign = createDoctorWithAssign(doctorToAssign, patientToAssign);
+        Patient patientWithAssign = createPatientWithAssign(doctorToAssign, patientToAssign);
 
         model.setDoctor(doctorToAssign, doctorWithAssign);
+        model.setPatient(patientToAssign, patientWithAssign);
         return new CommandResult(String.format(MESSAGE_ASSIGN_PATIENT_SUCCESS,
                 patientToAssign.getName().fullName,
                 doctorToAssign.getName().fullName));
@@ -78,6 +80,7 @@ public class AssignPatientCommand extends Command {
 
         patientsSet.add(patientToAssign);
 
+
         return new Doctor(doctorToAssign.getName(),
                 doctorToAssign.getPhone(),
                 doctorToAssign.getEmail(),
@@ -85,6 +88,32 @@ public class AssignPatientCommand extends Command {
                 doctorToAssign.getYoe(),
                 doctorToAssign.getTags(),
                 patientsSet);
+    }
+
+    private static Patient createPatientWithAssign(Doctor doctorToAssign, Patient patientToAssign)
+            throws CommandException {
+        assert doctorToAssign != null;
+        assert patientToAssign != null;
+        Set<Doctor> doctorsSet = patientToAssign.getDoctors();
+
+        if (doctorsSet.contains(doctorToAssign)) {
+            throw new CommandException(String.format(MESSAGE_PATIENT_ALREADY_ASSIGNED,
+                    patientToAssign.getName().fullName,
+                    doctorToAssign.getName().fullName));
+        }
+
+        doctorsSet.add(doctorToAssign);
+
+        return new Patient(patientToAssign.getName(),
+                patientToAssign.getPhone(),
+                patientToAssign.getEmail(),
+                patientToAssign.getHeight(),
+                patientToAssign.getWeight(),
+                patientToAssign.getDiagnosis(),
+                patientToAssign.getStatus(),
+                patientToAssign.getRemark(),
+                patientToAssign.getTags(),
+                doctorsSet);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/doctor/Doctor.java
+++ b/src/main/java/seedu/address/model/person/doctor/Doctor.java
@@ -145,9 +145,9 @@ public class Doctor extends Person {
 
         Set<Patient> patients = getPatients();
         if (!patients.isEmpty()) {
-            builder.append("; Patients: ");
+            builder.append("; Patients: | ");
             patients.forEach((Patient patient) -> {
-                builder.append(patient.getName());
+                builder.append(patient.getName() + " | ");
             });
         }
         return builder.toString();

--- a/src/main/java/seedu/address/model/person/doctor/DoctorFilter.java
+++ b/src/main/java/seedu/address/model/person/doctor/DoctorFilter.java
@@ -1,9 +1,12 @@
 package seedu.address.model.person.doctor;
 
+import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.commons.util.StringUtil;
+import seedu.address.model.person.patient.Patient;
 
 /**
  * Filter Class for passing to DoctorContainsKeywordsPredicate
@@ -17,6 +20,30 @@ public class DoctorFilter {
     private final String specialtyFilter;
     private final String yoeFilter;
     private final Set<String> tagsFilter;
+    private final Optional<Patient> patientFilter;
+
+    /**
+     * Constructs a {@code DoctorFilter}.
+     *
+     * @param name name in string (can be empty string).
+     * @param phone phone in string (can be empty string).
+     * @param email email in string (can be empty string).
+     * @param specialty specialty in string (can be empty string).
+     * @param yoe yoe in string (can be empty string).
+     * @param tags set of tags in string (can be empty list).
+     * @param patient optional containing patient object (OfNullable).
+     */
+    public DoctorFilter(String name, String phone, String email,
+                        String specialty, String yoe,
+                        Set<String> tags, Optional<Patient> patient) {
+        this.nameFilter = name;
+        this.phoneFilter = phone;
+        this.emailFilter = email;
+        this.specialtyFilter = specialty;
+        this.yoeFilter = yoe;
+        this.tagsFilter = tags;
+        this.patientFilter = patient;
+    }
 
     /**
      * Constructs a {@code DoctorFilter}.
@@ -28,17 +55,13 @@ public class DoctorFilter {
      * @param yoe yoe in string (can be empty string).
      * @param tags set of tags in string (can be empty list).
      */
-    public DoctorFilter(String name,
-                        String phone,
-                        String email,
-                        String specialty,
-                        String yoe, Set<String> tags) {
-        this.nameFilter = name;
-        this.phoneFilter = phone;
-        this.emailFilter = email;
-        this.specialtyFilter = specialty;
-        this.yoeFilter = yoe;
-        this.tagsFilter = tags;
+    public DoctorFilter(String name, String phone, String email,
+                        String specialty, String yoe, Set<String> tags) {
+        this(name, phone, email, specialty, yoe, tags, Optional.empty());
+    }
+
+    public DoctorFilter(Optional<Patient> patient) {
+        this("", "", "", "", "", new HashSet<>(), patient);
     }
 
     /**
@@ -65,6 +88,10 @@ public class DoctorFilter {
                     .collect(Collectors.toSet()));
         }
 
+        if (patientFilter.isPresent()) {
+            result = result && doctor.hasPatient(patientFilter.get());
+        }
+
         return result;
     }
 
@@ -77,6 +104,7 @@ public class DoctorFilter {
                 && this.emailFilter.equals(((DoctorFilter) other).emailFilter)
                 && this.specialtyFilter.equals(((DoctorFilter) other).specialtyFilter)
                 && this.yoeFilter.equals(((DoctorFilter) other).yoeFilter)
-                && this.tagsFilter.equals(((DoctorFilter) other).tagsFilter)); // state check
+                && this.tagsFilter.equals(((DoctorFilter) other).tagsFilter))
+                && this.patientFilter.equals(((DoctorFilter) other).patientFilter); // state check
     }
 }

--- a/src/main/java/seedu/address/model/person/patient/Patient.java
+++ b/src/main/java/seedu/address/model/person/patient/Patient.java
@@ -171,9 +171,9 @@ public class Patient extends Person {
 
         Set<Doctor> doctors = getDoctors();
         if (!doctors.isEmpty()) {
-            builder.append("; Doctors: ");
+            builder.append("; Doctors: | ");
             doctors.forEach((Doctor doctor) -> {
-                builder.append(doctor.getName());
+                builder.append(doctor.getName() + " | ");
             });
         }
         return builder.toString();

--- a/src/main/java/seedu/address/model/person/patient/PatientFilter.java
+++ b/src/main/java/seedu/address/model/person/patient/PatientFilter.java
@@ -1,9 +1,12 @@
 package seedu.address.model.person.patient;
 
+import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.commons.util.StringUtil;
+import seedu.address.model.person.doctor.Doctor;
 
 /**
  * Filter Class for passing to PatientContainsKeywordsPredicate
@@ -20,6 +23,36 @@ public class PatientFilter {
     private final String statusFilter;
     private final String remarkFilter;
     private final Set<String> tagsFilter;
+    private final Optional<Doctor> doctorFilter;
+
+    /**
+     * Constructs a {@code PatientFilter}.
+     *
+     * @param name name in string (can be empty string).
+     * @param phone phone in string (can be empty string).
+     * @param email email in string (can be empty string).
+     * @param height height in string (can be empty string).
+     * @param weight weight in string (can be empty string).
+     * @param diagnosis diagnosis in string (can be empty string).
+     * @param status status in string (can be empty string).
+     * @param remark remark in string (can be empty string).
+     * @param tags set of tags in string (can be empty list).
+     * @param doctor optional containing doctor object (OfNullable).
+     */
+    public PatientFilter(String name, String phone, String email, String height,
+                         String weight, String diagnosis, String status,
+                         String remark, Set<String> tags, Optional<Doctor> doctor) {
+        this.nameFilter = name;
+        this.phoneFilter = phone;
+        this.emailFilter = email;
+        this.heightFilter = height;
+        this.weightFilter = weight;
+        this.diagnosisFilter = diagnosis;
+        this.statusFilter = status;
+        this.remarkFilter = remark;
+        this.tagsFilter = tags;
+        this.doctorFilter = doctor;
+    }
 
     /**
      * Constructs a {@code PatientFilter}.
@@ -35,22 +68,25 @@ public class PatientFilter {
      * @param tags set of tags in string (can be empty list).
      */
     public PatientFilter(String name,
-                        String phone,
-                        String email,
-                        String height,
-                        String weight,
-                        String diagnosis,
-                        String status,
-                        String remark, Set<String> tags) {
-        this.nameFilter = name;
-        this.phoneFilter = phone;
-        this.emailFilter = email;
-        this.heightFilter = height;
-        this.weightFilter = weight;
-        this.diagnosisFilter = diagnosis;
-        this.statusFilter = status;
-        this.remarkFilter = remark;
-        this.tagsFilter = tags;
+                         String phone,
+                         String email,
+                         String height,
+                         String weight,
+                         String diagnosis,
+                         String status,
+                         String remark, Set<String> tags) {
+        this(name, phone, email, height, weight,
+                diagnosis, status, remark, tags, Optional.empty());
+    }
+
+    /**
+     * Constructs a {@code PatientFilter}.
+     *
+     * @param doctor optional containing doctor object (OfNullable).
+     */
+    public PatientFilter(Optional<Doctor> doctor) {
+        this("", "", "", "", "",
+                "", "", "", new HashSet<>(), doctor);
     }
 
     /**
@@ -80,6 +116,10 @@ public class PatientFilter {
                     .collect(Collectors.toSet()));
         }
 
+        if (doctorFilter.isPresent()) {
+            result = result && patient.hasDoctor(doctorFilter.get());
+        }
+
         return result;
     }
 
@@ -95,6 +135,7 @@ public class PatientFilter {
                 && this.diagnosisFilter.equals(((PatientFilter) other).diagnosisFilter)
                 && this.statusFilter.equals(((PatientFilter) other).statusFilter)
                 && this.remarkFilter.equals(((PatientFilter) other).remarkFilter)
-                && this.tagsFilter.equals(((PatientFilter) other).tagsFilter)); // state check
+                && this.tagsFilter.equals(((PatientFilter) other).tagsFilter))
+                && this.doctorFilter.equals(((PatientFilter) other).doctorFilter); // state check
     }
 }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
+import javafx.collections.ObservableList;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -83,18 +84,24 @@ class JsonSerializableAddressBook {
             }
             addressBook.addDoctor(doctor);
 
-            // Add Patients of the doctor into single patient list in AddressBook
-            if (doctor.hasPatients()) {
-                doctor.getPatients().forEach((Patient patient) -> {
-                    // Assign doctor to patient
-                    // This is done here as doctorsAssigned is not stored
-                    // within each patient json object
-                    patient.assignDoctor(doctor);
+            for (Patient patient : doctor.getPatients()) {
+                if (!addressBook.hasPatient(patient)) {
+                    addressBook.addPatient(patient);
+                }
+            }
+        }
 
-                    if (!addressBook.hasPatient(patient)) {
-                        addressBook.addPatient(patient);
-                    }
-                });
+        // Assign patients to doctors
+        ObservableList<Patient> addressBookPatientList = addressBook.getPatientList();
+        ObservableList<Doctor> addressBookDoctorList = addressBook.getDoctorList();
+        for (Patient patient : addressBookPatientList) {
+            for (Doctor doctor : addressBookDoctorList) {
+                // Assign doctor to patient
+                // This is done here as doctorsAssigned is not stored
+                // within each patient json object
+                if (doctor.hasPatient(patient)) {
+                    patient.assignDoctor(doctor);
+                }
             }
         }
 

--- a/src/main/java/seedu/address/ui/ContactDisplay.java
+++ b/src/main/java/seedu/address/ui/ContactDisplay.java
@@ -70,7 +70,7 @@ public class ContactDisplay extends UiPart<Region> {
         patientListPanelPlaceholder.getChildren().add(patientListPanel.getRoot());
 
         doctorListPanel = new DoctorListPanel(logic.getFilteredDoctorList(),
-                enlargedDoctorInfoCard, infoCardDisplayController, patientListPanel);
+                enlargedDoctorInfoCard, infoCardDisplayController, logic);
         doctorListPanelPlaceholder.getChildren().add(doctorListPanel.getRoot());
     }
 

--- a/src/main/java/seedu/address/ui/ContactDisplay.java
+++ b/src/main/java/seedu/address/ui/ContactDisplay.java
@@ -66,7 +66,7 @@ public class ContactDisplay extends UiPart<Region> {
         enlargedPersonInfoCardPlaceholder.getChildren().add(enlargedDoctorInfoCard.getRoot());
 
         patientListPanel = new PatientListPanel(logic.getFilteredPatientList(),
-                enlargedPatientInfoCard, infoCardDisplayController);
+                enlargedPatientInfoCard, infoCardDisplayController, logic);
         patientListPanelPlaceholder.getChildren().add(patientListPanel.getRoot());
 
         doctorListPanel = new DoctorListPanel(logic.getFilteredDoctorList(),

--- a/src/main/java/seedu/address/ui/DoctorListPanel.java
+++ b/src/main/java/seedu/address/ui/DoctorListPanel.java
@@ -48,7 +48,7 @@ public class DoctorListPanel extends UiPart<Region> {
             return generatedCell;
         });
         setSelectedDoctor(doctorList);
-        showSelectedDoctorInfo(enlargedDoctorInfoCard, logic);
+        showSelectedDoctorInfo(enlargedDoctorInfoCard);
     }
 
     /**
@@ -80,7 +80,7 @@ public class DoctorListPanel extends UiPart<Region> {
      * @param enlargedDoctorInfoCard the UI part displaying the information of {@code Doctor} selected
      */
     private void showSelectedDoctorInfo(
-            EnlargedDoctorInfoCard enlargedDoctorInfoCard, Logic logic) {
+            EnlargedDoctorInfoCard enlargedDoctorInfoCard) {
         ChangeListener<Doctor> changeListener = (observable, oldValue, newValue) -> {
             selectedDoctor = observable.getValue();
             enlargedDoctorInfoCard

--- a/src/main/java/seedu/address/ui/DoctorListPanel.java
+++ b/src/main/java/seedu/address/ui/DoctorListPanel.java
@@ -1,6 +1,7 @@
 package seedu.address.ui;
 
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.beans.value.ChangeListener;
@@ -12,7 +13,11 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Logic;
 import seedu.address.model.person.doctor.Doctor;
+import seedu.address.model.person.patient.Patient;
+import seedu.address.model.person.patient.PatientContainsKeywordsPredicate;
+import seedu.address.model.person.patient.PatientFilter;
 
 /**
  * Panel containing the list of doctors.
@@ -32,18 +37,18 @@ public class DoctorListPanel extends UiPart<Region> {
     public DoctorListPanel(ObservableList<Doctor> doctorList,
                            EnlargedDoctorInfoCard enlargedDoctorInfoCard,
                            EnlargedInfoCardDisplayController infoCardDisplayController,
-                           PatientListPanel patientListPanel) {
+                           Logic logic) {
         super(FXML);
         doctorListView.setItems(doctorList);
         doctorListView.setCellFactory(listView -> {
-            DoctorListViewCell generatedCell = new DoctorListViewCell();
+            DoctorListViewCell generatedCell = new DoctorListViewCell(logic);
             generatedCell.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
                 infoCardDisplayController.displayDoctor();
             });
             return generatedCell;
         });
         setSelectedDoctor(doctorList);
-        showSelectedDoctorInfo(enlargedDoctorInfoCard, patientListPanel);
+        showSelectedDoctorInfo(enlargedDoctorInfoCard, logic);
     }
 
     /**
@@ -68,17 +73,18 @@ public class DoctorListPanel extends UiPart<Region> {
     }
 
     /**
-     * Prompts {@code EnlargedDoctorInfoCard} to display the information of the {@code Doctor} selected by the user.
+     * Prompts {@code EnlargedDoctorInfoCard} to display the
+     * information of the {@code Doctor} selected by the user.
      * This is done by configuring a {@code ChangeListener} to listen to user selection.
      *
      * @param enlargedDoctorInfoCard the UI part displaying the information of {@code Doctor} selected
      */
     private void showSelectedDoctorInfo(
-            EnlargedDoctorInfoCard enlargedDoctorInfoCard,
-            PatientListPanel patientListPanel) {
+            EnlargedDoctorInfoCard enlargedDoctorInfoCard, Logic logic) {
         ChangeListener<Doctor> changeListener = (observable, oldValue, newValue) -> {
             selectedDoctor = observable.getValue();
-            enlargedDoctorInfoCard.updateSelectedDoctorOptional(Optional.ofNullable(selectedDoctor));
+            enlargedDoctorInfoCard
+                    .updateSelectedDoctorOptional(Optional.ofNullable(selectedDoctor));
         };
         doctorListView.getSelectionModel().selectedItemProperty().addListener(changeListener);
     }
@@ -106,9 +112,25 @@ public class DoctorListPanel extends UiPart<Region> {
      * Custom {@code ListCell} that displays the graphics of a {@code Doctor} using a {@code DoctorCard}.
      */
     class DoctorListViewCell extends ListCell<Doctor> {
+
+        private Optional<Doctor> doctor;
+
+        public DoctorListViewCell(Logic logic) {
+            super();
+            this.doctor = Optional.empty();
+            this.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
+                PatientFilter patientContainsDoctor =
+                        new PatientFilter(this.doctor);
+                Predicate<Patient> patientsOfDoctorPredicate =
+                        new PatientContainsKeywordsPredicate(patientContainsDoctor);
+                logic.updateFilteredPatientList(patientsOfDoctorPredicate);
+            });
+        }
+
         @Override
         protected void updateItem(Doctor doctor, boolean empty) {
             super.updateItem(doctor, empty);
+            this.doctor = Optional.ofNullable(doctor);
 
             if (empty || doctor == null) {
                 setGraphic(null);

--- a/src/main/java/seedu/address/ui/EnlargedInfoCardDisplayController.java
+++ b/src/main/java/seedu/address/ui/EnlargedInfoCardDisplayController.java
@@ -6,8 +6,8 @@ package seedu.address.ui;
  */
 public class EnlargedInfoCardDisplayController {
 
-    private boolean shouldDisplayDoctorInfoCard;
-    private boolean shouldDisplayPatientInfoCard;
+    private boolean shouldDisplayDoctorInfoCard = true;
+    private boolean shouldDisplayPatientInfoCard = false;
     private ContactDisplay parent;
 
     /**
@@ -15,7 +15,6 @@ public class EnlargedInfoCardDisplayController {
      * with the given parent {@code ContactDisplay}.
      */
     public EnlargedInfoCardDisplayController(ContactDisplay parent) {
-        // Show Doctor by default
         this.parent = parent;
     }
 

--- a/src/main/java/seedu/address/ui/PatientListPanel.java
+++ b/src/main/java/seedu/address/ui/PatientListPanel.java
@@ -1,6 +1,7 @@
 package seedu.address.ui;
 
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.beans.value.ChangeListener;
@@ -12,6 +13,10 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Logic;
+import seedu.address.model.person.doctor.Doctor;
+import seedu.address.model.person.doctor.DoctorContainsKeywordsPredicate;
+import seedu.address.model.person.doctor.DoctorFilter;
 import seedu.address.model.person.patient.Patient;
 
 /**
@@ -31,11 +36,11 @@ public class PatientListPanel extends UiPart<Region> {
      */
     public PatientListPanel(ObservableList<Patient> patientList,
                             EnlargedPatientInfoCard enlargedPatientInfoCard,
-                            EnlargedInfoCardDisplayController infoCardDisplayController) {
+                            EnlargedInfoCardDisplayController infoCardDisplayController, Logic logic) {
         super(FXML);
         patientListView.setItems(patientList);
         patientListView.setCellFactory(listView -> {
-            PatientListViewCell generatedCell = new PatientListViewCell();
+            PatientListViewCell generatedCell = new PatientListViewCell(logic);
             generatedCell.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
                 infoCardDisplayController.displayPatient();
             });
@@ -85,7 +90,8 @@ public class PatientListPanel extends UiPart<Region> {
             EnlargedPatientInfoCard enlargedPatientInfoCard) {
         ChangeListener<Patient> changeListener = (observable, oldValue, newValue) -> {
             selectedPatient = observable.getValue();
-            enlargedPatientInfoCard.updateSelectedPatientOptional(Optional.ofNullable(selectedPatient));
+            enlargedPatientInfoCard
+                    .updateSelectedPatientOptional(Optional.ofNullable(selectedPatient));
         };
         patientListView.getSelectionModel().selectedItemProperty().addListener(changeListener);
     }
@@ -113,9 +119,25 @@ public class PatientListPanel extends UiPart<Region> {
      * Custom {@code ListCell} that displays the graphics of a {@code Patient} using a {@code PatientCard}.
      */
     class PatientListViewCell extends ListCell<Patient> {
+
+        private Optional<Patient> patient;
+
+        public PatientListViewCell(Logic logic) {
+            super();
+            this.patient = Optional.empty();
+            this.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
+                DoctorFilter doctorContainsPatient =
+                        new DoctorFilter(this.patient);
+                Predicate<Doctor> doctorsOfPatientPredicate =
+                        new DoctorContainsKeywordsPredicate(doctorContainsPatient);
+                logic.updateFilteredDoctorList(doctorsOfPatientPredicate);
+            });
+        }
+
         @Override
         protected void updateItem(Patient patient, boolean empty) {
             super.updateItem(patient, empty);
+            this.patient = Optional.ofNullable(patient);
 
             if (empty || patient == null) {
                 setGraphic(null);


### PR DESCRIPTION
**What's been done**
- Ui components have been updated to ensure that selection of list card updates the sister list.
    - For example, selecting a doctor will update the patients' list, showing all patients associated with the doctor.
- During loading, assignment of doctors to patients will be done after all patients are added to the addressbook.

**Notes**
@Bobfree546 AssignPatientCommand has been amended to ensure that the doctor is added into the patient's list as well after assignment
@owen-yap PatientFilter and DoctorFilter has been amended to allow for filtering with doctor/patient respectively.